### PR TITLE
Extra zoekbox om leges op ID te vinden

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## Version 1.2.2
+
+### Feat
+
+-   Add search box to find leges items by ID
+
 ## version 1.2.1
 
 ### Fix

--- a/pdc-leges.php
+++ b/pdc-leges.php
@@ -4,7 +4,7 @@
  * Plugin Name:       PDC Leges
  * Plugin URI:        https://www.openwebconcept.nl
  * Description:       PDC Leges
- * Version:           1.2.1
+ * Version:           1.2.2
  * Author:            Yard Internet
  * Author URI:        https://www.yardinternet.nl/
  * License:           GPL-3.0

--- a/src/Leges/Foundation/Plugin.php
+++ b/src/Leges/Foundation/Plugin.php
@@ -27,7 +27,7 @@ class Plugin extends BasePlugin
      *
      * @const string VERSION
      */
-    const VERSION = '1.2.1';
+    const VERSION = '1.2.2';
 
     protected function checkForUpdate()
     {


### PR DESCRIPTION
Dit voegt een extra invoerveld "ID" toe op de "Alle leges"-overzichtspagina, waarmee een specifiek leges-item op ID gevonden kan worden.

![image](https://github.com/OpenWebconcept/plugin-pdc-leges/assets/47478535/b7b676ed-c5b5-4436-854a-99b243562c39)

(Op verzoek van twee gemeenten, support-cases 28649 en 28582.)